### PR TITLE
WIP: configurable base path

### DIFF
--- a/explorer/src/kv.ts
+++ b/explorer/src/kv.ts
@@ -1,0 +1,89 @@
+import { HttpResponse } from "@fermyon/spin-sdk";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+interface SetInput {
+    key: string,
+    value: string
+}
+
+interface GetResult {
+    store: string,
+    key: string,
+    value: ArrayBuffer
+}
+
+interface ListResult {
+    store: string,
+    keys: Array<string>
+}
+
+function listKeys(store: string): HttpResponse {
+    console.log(`Listing keys from store: ${store}`);
+
+    try {
+        let kv = spinSdk.kv.open(store);
+        let keys = kv.getKeys();
+        return {
+            status: 200,
+            body: encoder.encode(JSON.stringify({ store: store, keys: keys } as ListResult)).buffer
+        }
+    } catch (err) {
+        console.log(`Error: ${err}`);
+        return { status: 500 }
+    }
+}
+
+function getKey(store: string, key: string): HttpResponse {
+    console.log(`Getting the value of key ${key} from store: ${store}`);
+
+    try {
+        let kv = spinSdk.kv.open(store);
+        if (kv.exists(key)) {
+            return {
+                status: 200,
+                body: encoder.encode(JSON.stringify({ store: store, key: key, value: kv.get(key) } as GetResult)).buffer
+            }
+        } else {
+            return { status: 404 }
+        }
+    } catch (err) {
+        console.log(`Error: ${err}`);
+        return { status: 500 }
+    }
+}
+
+function deleteKey(store: string, key: string): HttpResponse {
+
+    console.log(`Deleting the value of key ${key} from store: ${store}`);
+
+    try {
+        let kv = spinSdk.kv.open(store);
+        if (kv.exists(key)) {
+            kv.delete(key);
+            return { status: 200 }
+        } else {
+            return { status: 404 }
+        }
+    } catch (err) {
+        console.log(`Error: ${err}`);
+        return { status: 500 }
+    }
+}
+
+function setKey(store: string, body: ArrayBuffer) {
+    let input = JSON.parse(decoder.decode(body)) as SetInput;
+    console.log(`Adding new value in store ${store}. Input: ${input.key}. Value: ${input.value}`)
+
+    try {
+        let kv = spinSdk.kv.open(store);
+        kv.set(input.key, input.value);
+        return { status: 200 }
+    } catch (err) {
+        console.log(`Error: ${err}`);
+        return { status: 500 }
+    }
+}
+
+export { deleteKey, getKey, listKeys, setKey }

--- a/explorer/src/page.ts
+++ b/explorer/src/page.ts
@@ -68,8 +68,8 @@ export function html(): string {
 
 
 	<script>
-
-		fetch("/internal/kv-explorer/api/stores/default")
+		let basepath = "";
+		fetch(basepath + "/kv-explorer/api/stores/default")
 			.then((response) => response.json())
 			.then((data) => {
 				data.keys.forEach((item) => {
@@ -87,7 +87,7 @@ export function html(): string {
 
 			$(\`#\${key}View\`).click(function () {
 				var key = $(this).data("key");
-				fetch(\`/internal/kv-explorer/api/stores/default/keys/\${key}\`).then((response) => response.json()).then((data) => {
+				fetch(basepath + \`/kv-explorer/api/stores/default/keys/\${key}\`).then((response) => response.json()).then((data) => {
 					let decoder = new TextDecoder();
 					let value = decoder.decode(new Uint8Array(data.value));
 					$("#valueContent").text(value);
@@ -98,7 +98,7 @@ export function html(): string {
 
 			$(\`#\${key}Delete\`).click(function () {
 				var key = $(this).data("key");
-				fetch(\`/internal/kv-explorer/api/stores/default/keys/\${key}\`, {
+				fetch(basepath + \`/kv-explorer/api/stores/default/keys/\${key}\`, {
 					method: 'DELETE',
 				})
 					.then(() => {
@@ -124,7 +124,7 @@ export function html(): string {
 				key: key,
 				value: value
 			};
-			fetch("/internal/kv-explorer/api/stores/default", {
+			fetch(basepath + "/kv-explorer/api/stores/default", {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'


### PR DESCRIPTION
This PR allows specifying a base path from the `spin.toml` for the `kv-explorer`. All the APIs and the and served front-end are adjusted based on the basepath set.

This is currently just a PoC at this point. If we do want to go ahead with this we would need to add some validation checks for the basepath to make sure it does not lead to a malformed URL path. 