### PR TITLE
Support exploring non-default KV stores

### DIFF
--- a/explorer/go.mod
+++ b/explorer/go.mod
@@ -1,9 +1,7 @@
 module github.com/golang_explorer
 
-go 1.17
+go 1.20
 
-require github.com/fermyon/spin/sdk/go v1.0.0
+require github.com/fermyon/spin/sdk/go/v2 v2.0.1
 
 require github.com/julienschmidt/httprouter v1.3.0 // indirect
-
-replace github.com/fermyon/spin/sdk/go v1.0.0 => github.com/radu-matei/spin/sdk/go v0.0.0-20230406224338-9d78631f2c2b

--- a/explorer/go.sum
+++ b/explorer/go.sum
@@ -1,4 +1,4 @@
+github.com/fermyon/spin/sdk/go/v2 v2.0.1 h1:cVfGCn68Z0O0zjqsNmIDAp9mTEcjedGx+KU+95zODDM=
+github.com/fermyon/spin/sdk/go/v2 v2.0.1/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/radu-matei/spin/sdk/go v0.0.0-20230406224338-9d78631f2c2b h1:YjGlkvD2pkytU/DdJI+Bg6Zc73SNLToCcKQjKV3H5pc=
-github.com/radu-matei/spin/sdk/go v0.0.0-20230406224338-9d78631f2c2b/go.mod h1:yb8lGesopgj/GwPzLPATxcOeqWZT/HjrzEFfwbztAXE=

--- a/explorer/index.html
+++ b/explorer/index.html
@@ -210,7 +210,16 @@
 
 				<div class="row">
 					<div class="col-md-9">
-
+						<div class="table-wrap">
+							<div class="row mb-2 add-kv">
+								<div class="col-md-6">
+									<input id="storeLabel" type="text" class="form-control mt-2" placeholder="Store Label">
+								</div>
+								<div class="col-md-2">
+									<button id="load-store" class="btn btn-outline-primary mt-2" title="Load Store">Load</button>
+								</div>
+							</div>
+						</div>
 						<div class="table-wrap">
 							<div class="row mb-2 add-kv">
 								<div class="col-md-6">
@@ -252,7 +261,7 @@
 							<code>GET</code> &mdash; read the docs for <a
 								href="https://developer.fermyon.com/spin/kv-store#storing-and-retrieving-data-from-your-default-keyvalue-store"
 								target="_blank">Storing &amp; Retrieving Data From Your
-								Default Key/Value Store</a> for guidance and examples.
+								Key/Value Stores</a> for guidance and examples.
 						</p>
 					</div>
 				</div>
@@ -289,13 +298,30 @@
 		integrity="sha512-6UofPqm0QupIL0kzS/UIzekR73/luZdC6i/kXDbWnLOJoqwklBK6519iUnShaYceJ0y4FaiPtX/hRnV/X/xlUQ=="
 		crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 	<script>
-		fetch("{{.SpinRoute}}api/stores/default")
-			.then((response) => response.json())
-			.then((data) => {
-				data.keys.sort().forEach((item) => {
-					insert(item);
+		let storeLabel = "";
+
+		$("#load-store").click(function() {
+			removeAllPairs();
+			storeLabel = $("#storeLabel").val();
+			if (storeLabel.length == 0) {
+				alert("Store label must not be empty");
+				return
+			}
+			// Catch an Internal error and alert that store does not exist
+			fetch(`{{.SpinRoute}}api/stores/${storeLabel}`)
+				.then((response) => {
+					if (response.status == 401) {
+						alert(`Access denied to store with label "${storeLabel}." Ensure the app is linked to the store with this label and that the label has been specified in the Spin manifest (spin.toml).`);
+						return
+					}
+					return response.json()
+				})
+				.then((data) => {
+					data.keys.sort().forEach((item) => {
+						insert(item);
+					});
 				});
-			});
+		})
 
 		// Use this to generate unique and valid ids for keys
 		const simpleHash = str => {
@@ -308,6 +334,10 @@
 			return new Uint32Array([hash])[0].toString(36);
 		};
 
+		function removeAllPairs() {
+			$("#kv > tbody:first").empty();
+		}
+
 		function insert(key) {
 			let hashedKey = simpleHash(key);
 			$("#kv > tbody:first").append(`
@@ -318,7 +348,7 @@
 
 			$(`#${hashedKey}View`).click(function () {
 				var key = $(this).data("key");
-				fetch(`{{.SpinRoute}}api/stores/default/keys/${encodeURIComponent(key)}`).then((response) => response.json()).then((data) => {
+				fetch(`{{.SpinRoute}}api/stores/${storeLabel}/keys/${encodeURIComponent(key)}`).then((response) => response.json()).then((data) => {
 					let value = atob(data.value);
 					$("#valueContent").text(value);
 					$("#viewModal").modal("show");
@@ -328,7 +358,7 @@
 
 			$(`#${hashedKey}Delete`).click(function () {
 				var key = $(this).data("key");
-				fetch(`{{.SpinRoute}}api/stores/default/keys/${encodeURIComponent(key)}`, {
+				fetch(`{{.SpinRoute}}api/stores/${storeLabel}/keys/${encodeURIComponent(key)}`, {
 					method: 'DELETE',
 				})
 					.then(() => {
@@ -354,7 +384,7 @@
 				key: key,
 				value: value
 			};
-			fetch("{{.SpinRoute}}api/stores/default", {
+			fetch(`{{.SpinRoute}}api/stores/${storeLabel}`, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'

--- a/readme.md
+++ b/readme.md
@@ -43,22 +43,24 @@ You can now access the explorer in your browser at the route `/internal/kv-explo
 
 ### Credentials
 
-When running locally, you can skip checking for the crendentials on every request by passing the `SPIN_APP_KV_SKIP_AUTH` environment variable:
+Locally, you configure variables using a [variable provider](https://developer.fermyon.com/spin/v2/dynamic-configuration#application-variables-runtime-configuration).
+For example, the username and password can be configured using the environment variable provider as follows:
+
+```bash
+$ SPIN_VARIABLE_KV_EXPLORER_USER=user SPIN_VARIABLE_KV_EXPLORER_PASSWORD=pw spin up
+```
+
+When running locally, you can skip checking for the credentials on every request by passing the `SPIN_APP_KV_SKIP_AUTH` environment variable:
 
 ```bash
 $ spin up --env SPIN_APP_KV_SKIP_AUTH=1
 ```
 
-When deploying to [Fermyon Cloud](https://fermyon.com/cloud), you can pass the credentials pair together with the `spin deploy` command:
+When deploying to [Fermyon Cloud](https://fermyon.com/cloud), you are required to set the username and password for the kv explorer with the `spin deploy` command:
 
 ```bash
 # change the value to your desired basic authentication credentials
-$ export KV_CREDENTIALS="user:password"
-$ spin deploy --key-value kv-credentials=$KV_CREDENTIALS
+$ spin deploy --variable kv_explorer_user="some-username" --variable kv_explorer_password="some-password"
 ```
 
-The explorer will use the default store to persist the credentials to access the UI and the API. If no values are set, the first invocation will set a randomly generated pair of username and password under the `kv-credentials` key, with the value following the `user:password` format. On the first run, the values will be printed in the logs, and they can be used to log in and change them (creating a new `credentials` value will override the existing value).
-
-### Known limitations
-
-- the explorer can only be used with Spin's default key/value store. When this will be configurable, this component will support working with custom stores as well.
+The explorer will use the config variables store to persist the credentials to access the UI and the API. If no values are set, a forbidden error is returned.

--- a/spin.toml
+++ b/spin.toml
@@ -5,6 +5,10 @@ name = "kv-explorer"
 version = "0.1.0"
 authors = ["Radu Matei <radu.matei@fermyon.com>"]
 
+[variables]
+kv_explorer_user = { required = true }
+kv_explorer_password = { required = true }
+
 [application.trigger.http]
 base = "/"
 
@@ -18,7 +22,10 @@ source = "explorer/main.wasm"
 allowed_outbound_hosts = ["redis://*:*", "mysql://*:*", "postgres://*:*"]
 key_value_stores = ["default"]
 
+[component.golang-explorer.variables]
+kv_credentials = "{{ kv_explorer_user }}:{{ kv_explorer_password }}"
+
 [component.golang-explorer.build]
-command = "tinygo build -target=wasi -gc=leaking -o main.wasm main.go"
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
 workdir = "explorer"
-watch = ["**/*.go", "go.mod"]
+watch = ["**/*.go", "go.mod", "index.html"]


### PR DESCRIPTION
Supports exploring non-default KV stores by adding a top level field to specify the label of which store to explore
Stores the user/pass credentials in the app config store instead of in the "default" KV store

![image](https://github.com/fermyon/spin-kv-explorer/assets/19913192/55564e76-5340-4579-b52b-d887e4deb6c1)

~Draft as there is currently an issue getting the template to work with variables~ << Thanks @itowlson!

Thank you @karthik2804 for help with the UI!!

To test it, follow updated README instructions

Associated template updates: https://github.com/fermyon/spin-kv-explorer/pull/28