### PR TITLE
Output descriptive filename during Spin builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: generate checksums
         run: |
-          sha256sum explorer/main.wasm > checksums.txt
+          sha256sum explorer/spin-kv-explorer.wasm > checksums.txt
 
       - name: Create release
         uses: softprops/action-gh-release@v1
@@ -47,5 +47,5 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           files: |
-            explorer/main.wasm
+            explorer/spin-kv-explorer.wasm
             checksums.txt

--- a/explorer/.gitignore
+++ b/explorer/.gitignore
@@ -1,2 +1,2 @@
-main.wasm
+spin-kv-explorer.wasm
 .spin/

--- a/spin.toml
+++ b/spin.toml
@@ -18,7 +18,7 @@ component = "golang-explorer"
 route = "/internal/kv-explorer/..."
 
 [component.golang-explorer]
-source = "explorer/main.wasm"
+source = "explorer/spin-kv-explorer.wasm"
 allowed_outbound_hosts = ["redis://*:*", "mysql://*:*", "postgres://*:*"]
 key_value_stores = ["default"]
 
@@ -26,6 +26,6 @@ key_value_stores = ["default"]
 kv_credentials = "{{ kv_explorer_user }}:{{ kv_explorer_password }}"
 
 [component.golang-explorer.build]
-command = "tinygo build -target=wasi -gc=leaking -no-debug -o main.wasm main.go"
+command = "tinygo build -target=wasi -gc=leaking -no-debug -o spin-kv-explorer.wasm main.go"
 workdir = "explorer"
 watch = ["**/*.go", "go.mod", "index.html"]


### PR DESCRIPTION
Would be nice to be able to continue to have the templates point to a file with a descriptive name (rather than `main.wasm`):
```
[component.kv-explorer]
source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.9.0/spin-kv-explorer.wasm", digest = "sha256:07f5f0b8514c14ae5830af0f21674fd28befee33cd7ca58bc0a68103829f2f9c" }
```