### PR TITLE
Update template to v0.10.0

### DIFF
--- a/templates/kv-explorer/content/spin.toml
+++ b/templates/kv-explorer/content/spin.toml
@@ -13,6 +13,6 @@ component = "kv-explorer"
 route = "/internal/kv-explorer/..."
 
 [component.kv-explorer]
-source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.9.0/spin-kv-explorer.wasm", digest = "sha256:07f5f0b8514c14ae5830af0f21674fd28befee33cd7ca58bc0a68103829f2f9c" }
-allowed_outbound_hosts = ["redis://*:*", "mysql://*:*", "postgres://*:*"]
+source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.10.0/spin-kv-explorer.wasm", digest = "sha256:65bc286f8315746d1beecd2430e178f539fa487ebf6520099daae09a35dbce1d" }
 key_value_stores = ["default"]
+

--- a/templates/kv-explorer/metadata/snippets/component.txt
+++ b/templates/kv-explorer/metadata/snippets/component.txt
@@ -4,6 +4,6 @@ component = "kv-explorer"
 route = "/internal/kv-explorer/..."
 
 [component.kv-explorer]
-source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.9.0/spin-kv-explorer.wasm", digest = "sha256:07f5f0b8514c14ae5830af0f21674fd28befee33cd7ca58bc0a68103829f2f9c" }
-allowed_outbound_hosts = ["redis://*:*", "mysql://*:*", "postgres://*:*"]
+source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.10.0/spin-kv-explorer.wasm", digest = "sha256:65bc286f8315746d1beecd2430e178f539fa487ebf6520099daae09a35dbce1d" }
 key_value_stores = ["default"]
+


### PR DESCRIPTION
- Updated the template to v.0.10.0
- Removed `allowed_outbound_hosts` to databases, as databases are not supported by the explorer.