### PR TITLE
Template for KV explorer with Labels (Take 2)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,21 +22,31 @@ Installed 1 template(s)
 Then, you can either create a new application, or add this component to your existing app:
 
 ```bash
-$ spin new kv-explorer
+$ spin new -t kv-explorer
 # OR
-$ spin add kv-explorer
+$ spin add -t kv-explorer
 ```
 
 This will create the following component in your `spin.toml`:
 
 ```toml
-[[component]]
-source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/<latest-release>/spin-kv-explorer.wasm", digest = "sha256:aaa" }
-id = "kv-explorer"
+[[trigger.http]]
+component = "kv-explorer"
+route = "/internal/kv-explorer/..."
+
+[component.kv-explorer]
+source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.10.0/spin-kv-explorer.wasm", digest = "sha256:65bc286f8315746d1beecd2430e178f539fa487ebf6520099daae09a35dbce1d" }
+allowed_outbound_hosts = ["redis://*:*", "mysql://*:*", "postgres://*:*"]
 # add or remove stores you want to explore here
 key_value_stores = ["default"]
-[component.trigger]
-route = "/internal/kv-explorer/..."
+
+[component.kv-explorer.variables]
+kv_credentials = "{{ kv_explorer_user }}:{{ kv_explorer_password }}"
+
+[variables]
+kv_explorer_user = { required = true }
+kv_explorer_password = { required = true }
+
 ```
 
 You can now access the explorer in your browser at the route `/internal/kv-explorer`.

--- a/templates/kv-explorer/content/spin.toml
+++ b/templates/kv-explorer/content/spin.toml
@@ -4,15 +4,20 @@ spin_manifest_version = 2
 name = "{{project-name}}"
 version = "0.1.0"
 
+[variables]
+kv_explorer_user = { required = true }
+kv_explorer_password = { required = true }
+
 [application.trigger.http]
 base = "/"
 
 [[trigger.http]]
-id = "trigger-kv-explorer"
-component = "kv-explorer"
+component = "{{project-name | kebab_case}}"
 route = "/internal/kv-explorer/..."
 
-[component.kv-explorer]
-source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.9.0/spin-kv-explorer.wasm", digest = "sha256:07f5f0b8514c14ae5830af0f21674fd28befee33cd7ca58bc0a68103829f2f9c" }
-allowed_outbound_hosts = ["redis://*:*", "mysql://*:*", "postgres://*:*"]
+[component.{{project-name | kebab_case}}]
+source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.10.0/spin-kv-explorer.wasm", digest = "sha256:65bc286f8315746d1beecd2430e178f539fa487ebf6520099daae09a35dbce1d" }
 key_value_stores = ["default"]
+
+[component.{{project-name | kebab_case}}.variables]
+{% raw %}kv_credentials = "{{ kv_explorer_user }}:{{ kv_explorer_password }}"{% endraw %} 

--- a/templates/kv-explorer/metadata/snippets/component.txt
+++ b/templates/kv-explorer/metadata/snippets/component.txt
@@ -1,9 +1,12 @@
 [[trigger.http]]
-id = "trigger-kv-explorer"
-component = "kv-explorer"
+component = "{{project-name | kebab_case}}"
 route = "/internal/kv-explorer/..."
 
-[component.kv-explorer]
-source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.9.0/spin-kv-explorer.wasm", digest = "sha256:07f5f0b8514c14ae5830af0f21674fd28befee33cd7ca58bc0a68103829f2f9c" }
+[component.{{project-name | kebab_case}}]
+source = { url = "https://github.com/fermyon/spin-kv-explorer/releases/download/v0.10.0/spin-kv-explorer.wasm", digest = "sha256:65bc286f8315746d1beecd2430e178f539fa487ebf6520099daae09a35dbce1d" }
 allowed_outbound_hosts = ["redis://*:*", "mysql://*:*", "postgres://*:*"]
+# add or remove stores you want to explore here
 key_value_stores = ["default"]
+
+[component.{{project-name | kebab_case}}.variables]
+{% raw %}kv_credentials = "{{ kv_explorer_user }}:{{ kv_explorer_password }}"{% endraw %}

--- a/templates/kv-explorer/metadata/snippets/variables.txt
+++ b/templates/kv-explorer/metadata/snippets/variables.txt
@@ -1,0 +1,2 @@
+kv_explorer_user = { required = true }
+kv_explorer_password = { required = true }

--- a/templates/kv-explorer/metadata/spin-template.toml
+++ b/templates/kv-explorer/metadata/spin-template.toml
@@ -7,6 +7,7 @@ tags = ["http", "kv"]
 [add_component]
 skip_files = ["spin.toml"]
 [add_component.snippets]
+variables = "variables.txt"
 component = "component.txt"
 
 [parameters]


### PR DESCRIPTION
Recreation of PR https://github.com/fermyon/spin-kv-explorer/pull/28 after reverting it due to potential delay in support of KV links in Fermyon cloud. Draft until known date of support is reestablished. 